### PR TITLE
One major annoyance fixed (sorting) and a minor addition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,10 +237,6 @@ var mounts = [
     {itemName: "Palomino Horse", slots: "BC", quality: "common"},
     {itemName: "Sabino Horse", slots: "BE", quality: "common"},
     {itemName: "Waterdeep Horse", slots: "DE", quality: "common"},
-	
-	
-	{itemName: "", slots: "", quality: "legendary"},
-	
 ];
 function wordySlots(slots) {
     "use strict";

--- a/index.html
+++ b/index.html
@@ -359,6 +359,50 @@ function initialize() {
     var row;
     var cell;
     var link;
+	bonuses.sort(function (a, b) {
+		return a.itemName.localeCompare(b.itemName);
+	});
+	mounts.sort(function (a, b) {
+		var ordera=0;
+		var orderb=0;
+		switch (a.quality) {
+			case 'legendary':
+				ordera=10000;
+				break;
+			case 'epic':
+				ordera=1000;
+				break;
+			case 'rare':
+				ordera=100;
+				break;
+			case 'uncommon':
+				ordera=10;
+				break;
+			case 'common':
+				ordera=1;
+				break;
+		}
+		switch (b.quality) {
+			case 'legendary':
+				orderb=10000;
+				break;
+			case 'epic':
+				orderb=1000;
+				break;
+			case 'rare':
+				orderb=100;
+				break;
+			case 'uncommon':
+				orderb=10;
+				break;
+			case 'common':
+				orderb=1;
+				break;
+		}
+		console.log(ordera-orderb);
+		return a.itemName.localeCompare(b.itemName)+orderb-ordera;
+		return a.itemName.localeCompare(b.itemName);
+	});
     while (i < bonuses.length) {
         row = table.insertRow(table.rows.length);
         cell = row.insertCell(0);

--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@ var insignia = {
     "?": "FIXME"
 };
 var bonuses = [
-    {itemName: "bonuses", slots: "", description: ""},
-    {itemName: "mounts", slots: "", description: ""},
+    {itemName: "-- bonuses --", slots: "", description: ""},
+    {itemName: "-- mounts --", slots: "", description: ""},
     {itemName: "Vampire's Craving", slots: "AAB", description: "Whenever you perform a Lifesteal, you are healed for 3% of your maximum Hit Points over 4 seconds."},
     {itemName: "Survivor's Blessing", slots: "AAC", description: "Whenever you Deflect an attack, you are healed for 3% of your maximum Hit Points over 4 seconds."},
     {itemName: "Slayer's Redemption", slots: "AAE", description: "Whenever you kill a target, you are healed for 10% of your maximum Hit Points over 5 seconds."},

--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@ a:hover {text-decoration: underline;}
 </style>
 </head>
 <body>
+
+Updated version of <a href="https://two30.github.io/neverwinter-insignia/">Two30's Neverwinter Mount Insignia Bonuses tool</a>
+<br>
+<br>
+	
 <select id="select" onchange="update()"></select>
 <span id="slots"></span>
 <div id="description"></div>


### PR DESCRIPTION
I was always annoyed by the unsorted list of insignia bonuses, now auto sorts both the mount and bonus list.
Bonus list is just name based A-Z sorting, mount list is Quality then name A-Z.

Added Two30 credit which was missing from page.